### PR TITLE
Fix 'use strict' declaration.

### DIFF
--- a/chain.js
+++ b/chain.js
@@ -7,7 +7,7 @@
  *  https://github.com/switer/chainjs/blob/master/LICENSE
  */
 
-'use strict;'
+'use strict';
 
 /**
  *  Util functions


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode

> put the exact statement "use strict"; (or 'use strict';) in the function's body before any other statements.

(As far as the semicolon on the line, AFAIK, there's contention over whether a literal ; is required after the string (rather than an ASI-inserted semicolon). I'd include it to err on the safe side.)
